### PR TITLE
Add method overloads to support tournament url or id as param 

### DIFF
--- a/Challonge/Api/ChallongeClient.cs
+++ b/Challonge/Api/ChallongeClient.cs
@@ -187,25 +187,36 @@ namespace Challonge.Api
             return await OpenTournamentForPredictionsAsync(tournament.Id.ToString());
         }
 
-        public async Task<IEnumerable<Participant>> GetParticipantsAsync(Tournament tournament)
+        public async Task<IEnumerable<Participant>> GetParticipantsAsync(string tournament)
         {
             IEnumerable<ParticipantWrapper> wrappers = await SendRequestAsync<IEnumerable<ParticipantWrapper>>(
-                $"tournaments/{tournament.Id}/participants.json", HttpMethod.Get);
+                $"tournaments/{tournament}/participants.json", HttpMethod.Get);
 
             return wrappers.Select(w => w.Item);
         }
+        
+        public async Task<IEnumerable<Participant>> GetParticipantsAsync(Tournament tournament)
+        {
+            return await GetParticipantsAsync(tournament.Id.ToString());
+        }
 
-        public async Task<Participant> CreateParticipantAsync(Tournament tournament, ParticipantInfo participantInfo, 
+        public async Task<Participant> CreateParticipantAsync(string tournament, ParticipantInfo participantInfo, 
             bool ignoreNulls = true)
         {
             ParticipantWrapper wrapper = await SendRequestAsync<ParticipantWrapper>(
-                $"tournaments/{tournament.Id}/participants.json", HttpMethod.Post,
+                $"tournaments/{tournament}/participants.json", HttpMethod.Post,
                 participantInfo.ToDictionary(ignoreNulls));
 
             return wrapper.Item;
         }
+        
+        public async Task<Participant> CreateParticipantAsync(Tournament tournament, ParticipantInfo participantInfo, 
+            bool ignoreNulls = true)
+        {
+            return await CreateParticipantAsync(tournament.Id.ToString(), participantInfo, ignoreNulls);
+        }
 
-        public async Task<IEnumerable<Participant>> CreateParticipantsAsync(Tournament tournament,
+        public async Task<IEnumerable<Participant>> CreateParticipantsAsync(string tournament,
             IEnumerable<ParticipantInfo> participantInfos)
         {
             // we convert the participantInfos to a list of dictionaries, and we do not ignore null values
@@ -229,17 +240,28 @@ namespace Challonge.Api
             }
 
             IEnumerable<ParticipantWrapper> wrappers = await SendRequestAsync<IEnumerable<ParticipantWrapper>>(
-                $"tournaments/{tournament.Id}/participants/bulk_add.json", HttpMethod.Post, parameters);
+                $"tournaments/{tournament}/participants/bulk_add.json", HttpMethod.Post, parameters);
 
             return wrappers.Select(w => w.Item);
         }
+        
+        public async Task<IEnumerable<Participant>> CreateParticipantsAsync(Tournament tournament,
+            IEnumerable<ParticipantInfo> participantInfos)
+        {
+            return await CreateParticipantsAsync(tournament.Id.ToString(), participantInfos);
+        }
 
-        public async Task<Participant> GetParticipantAsync(Tournament tournament, long participantId)
+        public async Task<Participant> GetParticipantAsync(string tournament, long participantId)
         {
             ParticipantWrapper wrapper = await SendRequestAsync<ParticipantWrapper>(
-                $"tournaments/{tournament.Id}/participants/{participantId}.json", HttpMethod.Get);
+                $"tournaments/{tournament}/participants/{participantId}.json", HttpMethod.Get);
 
             return wrapper.Item;
+        }
+        
+        public async Task<Participant> GetParticipantAsync(Tournament tournament, long participantId)
+        {
+            return await GetParticipantAsync(tournament.Id.ToString(), participantId);
         }
 
         public async Task<Participant> UpdateParticipantAsync(Participant participant, ParticipantInfo participantInfo, 
@@ -277,20 +299,30 @@ namespace Challonge.Api
                 HttpMethod.Delete);
         }
 
-        public async Task ClearParticipantsAsync(Tournament tournament)
+        public async Task ClearParticipantsAsync(string tournament)
         {
             await SendRequestAsync<ChallongeMessage>(
-                $"tournaments/{tournament.Id}/participants/clear.json",
+                $"tournaments/{tournament}/participants/clear.json",
                 HttpMethod.Delete);
         }
+        
+        public async Task ClearParticipantsAsync(Tournament tournament)
+        {
+            await ClearParticipantsAsync(tournament.Id.ToString());
+        }
 
-        public async Task<IEnumerable<Participant>> RandomizeParticipantsAsync(Tournament tournament)
+        public async Task<IEnumerable<Participant>> RandomizeParticipantsAsync(string tournament)
         {
             IEnumerable<ParticipantWrapper> wrappers = await SendRequestAsync<IEnumerable<ParticipantWrapper>>(
-                $"tournaments/{tournament.Id}/participants/randomize.json",
+                $"tournaments/{tournament}/participants/randomize.json",
                 HttpMethod.Post);
 
             return wrappers.Select(w => w.Item);
+        }
+        
+        public async Task<IEnumerable<Participant>> RandomizeParticipantsAsync(Tournament tournament)
+        {
+            return await RandomizeParticipantsAsync(tournament.Id.ToString());
         }
 
         public async Task<IEnumerable<Match>> GetMatchesAsync(Tournament tournament, 

--- a/Challonge/Api/ChallongeClient.cs
+++ b/Challonge/Api/ChallongeClient.cs
@@ -83,68 +83,108 @@ namespace Challonge.Api
             return GetTournamentByUrlAsync(id.ToString());
         }
 
-        public async Task<Tournament> UpdateTournamentAsync(Tournament tournament, TournamentInfo tournamentInfo, 
-            bool ignoreNulls = true)
+        public async Task<Tournament> UpdateTournamentAsync(string tournament, TournamentInfo tournamentInfo, bool ignoreNulls = true)
         {
             TournamentWrapper wrapper = await SendRequestAsync<TournamentWrapper>(
-                $"tournaments/{tournament.Id}.json", HttpMethod.Put,
+                $"tournaments/{tournament}.json", HttpMethod.Put,
                 tournamentInfo.ToDictionary(ignoreNulls));
 
             return wrapper.Item;
         }
 
-        public async Task DeleteTournamentAsync(Tournament tournament)
+        public async Task<Tournament> UpdateTournamentAsync(Tournament tournament, TournamentInfo tournamentInfo, 
+            bool ignoreNulls = true)
+        {
+            return await UpdateTournamentAsync(tournament.Id.ToString(), tournamentInfo, ignoreNulls);
+        }
+
+        public async Task DeleteTournamentAsync(string tournament)
         {
             await SendRequestAsync<TournamentWrapper>(
-                $"tournaments/{tournament.Id}.json", HttpMethod.Delete);
+                $"tournaments/{tournament}.json", HttpMethod.Delete);
+        }
+
+        public async Task DeleteTournamentAsync(Tournament tournament)
+        {
+            await DeleteTournamentAsync(tournament.Id.ToString());
+        }
+
+        public async Task<Tournament> ProcessTournamentCheckInsAsync(string tournament)
+        {
+            TournamentWrapper wrapper = await SendRequestAsync<TournamentWrapper>(
+                $"tournaments/{tournament}/process_check_ins.json", HttpMethod.Post);
+
+            return wrapper.Item;
         }
 
         public async Task<Tournament> ProcessTournamentCheckInsAsync(Tournament tournament)
         {
+            return await ProcessTournamentCheckInsAsync(tournament.Id.ToString());
+        }
+
+        public async Task<Tournament> AbortTournamentCheckInAsync(string tournament)
+        {
             TournamentWrapper wrapper = await SendRequestAsync<TournamentWrapper>(
-                $"tournaments/{tournament.Id}/process_check_ins.json", HttpMethod.Post);
+                $"tournaments/{tournament}/abort_check_in.json", HttpMethod.Post);
 
             return wrapper.Item;
         }
-
+        
         public async Task<Tournament> AbortTournamentCheckInAsync(Tournament tournament)
         {
+            return await AbortTournamentCheckInAsync(tournament.Id.ToString());
+        }
+
+        public async Task<Tournament> StartTournamentAsync(string tournament)
+        {
             TournamentWrapper wrapper = await SendRequestAsync<TournamentWrapper>(
-                $"tournaments/{tournament.Id}/abort_check_in.json", HttpMethod.Post);
+                $"tournaments/{tournament}/start.json", HttpMethod.Post);
 
             return wrapper.Item;
         }
-
+        
         public async Task<Tournament> StartTournamentAsync(Tournament tournament)
         {
+            return await StartTournamentAsync(tournament.Id.ToString());
+        }
+
+        public async Task<Tournament> FinalizeTournamentAsync(string tournament)
+        {
             TournamentWrapper wrapper = await SendRequestAsync<TournamentWrapper>(
-                $"tournaments/{tournament.Id}/start.json", HttpMethod.Post);
+                $"tournaments/{tournament}/finalize.json", HttpMethod.Post);
 
             return wrapper.Item;
         }
-
+        
         public async Task<Tournament> FinalizeTournamentAsync(Tournament tournament)
         {
+            return await FinalizeTournamentAsync(tournament.Id.ToString());
+        }
+
+        public async Task<Tournament> ResetTournamentAsync(string tournament)
+        {
             TournamentWrapper wrapper = await SendRequestAsync<TournamentWrapper>(
-                $"tournaments/{tournament.Id}/finalize.json", HttpMethod.Post);
+                $"tournaments/{tournament}/reset.json", HttpMethod.Post);
 
             return wrapper.Item;
         }
-
+        
         public async Task<Tournament> ResetTournamentAsync(Tournament tournament)
         {
+            return await ResetTournamentAsync(tournament.Id.ToString());
+        }
+
+        public async Task<Tournament> OpenTournamentForPredictionsAsync(string tournament)
+        {
             TournamentWrapper wrapper = await SendRequestAsync<TournamentWrapper>(
-                $"tournaments/{tournament.Id}/reset.json", HttpMethod.Post);
+                $"tournaments/{tournament}/open_for_predictions.json", HttpMethod.Post);
 
             return wrapper.Item;
         }
-
+        
         public async Task<Tournament> OpenTournamentForPredictionsAsync(Tournament tournament)
         {
-            TournamentWrapper wrapper = await SendRequestAsync<TournamentWrapper>(
-                $"tournaments/{tournament.Id}/open_for_predictions.json", HttpMethod.Post);
-
-            return wrapper.Item;
+            return await OpenTournamentForPredictionsAsync(tournament.Id.ToString());
         }
 
         public async Task<IEnumerable<Participant>> GetParticipantsAsync(Tournament tournament)
@@ -176,7 +216,7 @@ namespace Challonge.Api
                 JsonConvert.DeserializeObject<IEnumerable<Dictionary<string, object>>>(
                     JsonConvert.SerializeObject(participantInfos, settings));
 
-            List<KeyValuePair<string, object>> parameters = new();
+            List<KeyValuePair<string, object>> parameters = new List<KeyValuePair<string, object>>();
             foreach (Dictionary<string, object> dict in dicts)
             {
                 // bulk add takes invite_name_or email instead of challonge_username and email

--- a/Challonge/Api/IChallongeClient.cs
+++ b/Challonge/Api/IChallongeClient.cs
@@ -208,7 +208,18 @@ namespace Challonge.Api
         /// <param name="tournament">The tournament to open for predictions.</param>
         /// <returns>A task representing the updated tournament.</returns>
         public Task<Tournament> OpenTournamentForPredictionsAsync(Tournament tournament);
-
+        
+        /// <summary>
+        /// Gets all of a tournament's participants.
+        /// </summary>
+        /// <param name="tournament">
+        /// The tournament whose participants are to be retrieved.
+        /// Can be the tournament's id (e.g. 10230) or url (e.g 'single_elim' for 'challonge.com/single_elim')
+        /// If assigned to a subdomain, URL format must be subdomain-tournament_url (e.g. 'test-mytourney' for 'test.challonge.com/mytourney')
+        /// </param>
+        /// <returns>A task representing the tournament's participants.</returns>
+        public Task<IEnumerable<Participant>> GetParticipantsAsync(string tournament);
+        
         /// <summary>
         /// Gets all of a tournament's participants.
         /// </summary>
@@ -216,6 +227,19 @@ namespace Challonge.Api
         /// <returns>A task representing the tournament's participants.</returns>
         public Task<IEnumerable<Participant>> GetParticipantsAsync(Tournament tournament);
 
+        /// <summary>
+        /// Adds a new participant to a tournament.
+        /// </summary>
+        /// <param name="tournament">
+        /// The tournament to which to add the new participant.
+        /// Can be the tournament's id (e.g. 10230) or url (e.g 'single_elim' for 'challonge.com/single_elim')
+        /// If assigned to a subdomain, URL format must be subdomain-tournament_url (e.g. 'test-mytourney' for 'test.challonge.com/mytourney')
+        /// </param>
+        /// <param name="participantInfo">The details of the new participant.</param>
+        /// <param name="ignoreNulls">Indicates whether null-valued properties of participantInfo should be sent to Challonge.</param>
+        /// <returns>A task representing the new participant.</returns>
+        public Task<Participant> CreateParticipantAsync(string tournament, ParticipantInfo participantInfo, bool ignoreNulls = true);
+        
         /// <summary>
         /// Adds a new participant to a tournament.
         /// </summary>
@@ -231,10 +255,37 @@ namespace Challonge.Api
         /// <remarks>
         /// If an invalid participant is detected, bulk participant creation will halt and any previously added participants (from this API request) will be rolled back. 
         /// </remarks>
+        /// <param name="tournament">
+        /// The tournament to which to add the new participants.
+        /// Can be the tournament's id (e.g. 10230) or url (e.g 'single_elim' for 'challonge.com/single_elim')
+        /// If assigned to a subdomain, URL format must be subdomain-tournament_url (e.g. 'test-mytourney' for 'test.challonge.com/mytourney')
+        /// </param>
+        /// <param name="participantInfos">The details of the new participants.</param>
+        /// <returns>A task representing the new participants</returns>
+        public Task<IEnumerable<Participant>> CreateParticipantsAsync(string tournament, IEnumerable<ParticipantInfo> participantInfos);
+        
+        /// <summary>
+        /// Adds a group of new participants to a tournament.
+        /// </summary>
+        /// <remarks>
+        /// If an invalid participant is detected, bulk participant creation will halt and any previously added participants (from this API request) will be rolled back. 
+        /// </remarks>
         /// <param name="tournament">The tournament to which to add the new participants.</param>
         /// <param name="participantInfos">The details of the new participants.</param>
         /// <returns>A task representing the new participants</returns>
         public Task<IEnumerable<Participant>> CreateParticipantsAsync(Tournament tournament, IEnumerable<ParticipantInfo> participantInfos);
+
+        /// <summary>
+        /// Gets a participant.
+        /// </summary>
+        /// <param name="tournament">
+        /// The participant's tournament.
+        /// Can be the tournament's id (e.g. 10230) or url (e.g 'single_elim' for 'challonge.com/single_elim')
+        /// If assigned to a subdomain, URL format must be subdomain-tournament_url (e.g. 'test-mytourney' for 'test.challonge.com/mytourney')
+        /// </param>
+        /// <param name="participantId">The participant's ID.</param>
+        /// <returns>A task representing the participant.</returns>
+        public Task<Participant> GetParticipantAsync(string tournament, long participantId);
 
         /// <summary>
         /// Gets a participant.
@@ -278,10 +329,32 @@ namespace Challonge.Api
         /// <summary>
         /// Deletes all participants of a tournament if the tournament has not yet started.
         /// </summary>
+        /// <param name="tournament">
+        /// The tournament whose participants are to be deleted.
+        /// /// Can be the tournament's id (e.g. 10230) or url (e.g 'single_elim' for 'challonge.com/single_elim')
+        /// If assigned to a subdomain, URL format must be subdomain-tournament_url (e.g. 'test-mytourney' for 'test.challonge.com/mytourney')
+        /// </param>
+        /// <returns>An empty task.</returns>
+        public Task ClearParticipantsAsync(string tournament);
+        
+        /// <summary>
+        /// Deletes all participants of a tournament if the tournament has not yet started.
+        /// </summary>
         /// <param name="tournament">The tournament whose participants are to be deleted.</param>
         /// <returns>An empty task.</returns>
         public Task ClearParticipantsAsync(Tournament tournament);
 
+        /// <summary>
+        /// Randomizes a tournament's seeds if it has not yet started.
+        /// </summary>
+        /// <param name="tournament">
+        /// The tournament for which to randomize seeds.
+        /// Can be the tournament's id (e.g. 10230) or url (e.g 'single_elim' for 'challonge.com/single_elim')
+        /// If assigned to a subdomain, URL format must be subdomain-tournament_url (e.g. 'test-mytourney' for 'test.challonge.com/mytourney')
+        /// </param>
+        /// <returns>A task representing the updated participants.</returns>
+        public Task<IEnumerable<Participant>> RandomizeParticipantsAsync(string tournament);
+        
         /// <summary>
         /// Randomizes a tournament's seeds if it has not yet started.
         /// </summary>

--- a/Challonge/Api/IChallongeClient.cs
+++ b/Challonge/Api/IChallongeClient.cs
@@ -47,6 +47,19 @@ namespace Challonge.Api
         /// <summary>
         /// Updates an existing tournament.
         /// </summary>
+        /// <param name="tournament">
+        /// The tournament to update.
+        /// Can be the tournament's id (e.g. 10230) or url (e.g 'single_elim' for 'challonge.com/single_elim')
+        /// If assigned to a subdomain, URL format must be subdomain-tournament_url (e.g. 'test-mytourney' for 'test.challonge.com/mytourney') 
+        /// </param>
+        /// <param name="tournamentInfo">The new details of the tournament.</param>
+        /// <param name="ignoreNulls">Indicates whether null-valued properties of tournamentInfo should be sent to Challonge.</param>
+        /// <returns>A task representing the updated tournament.</returns>
+        public Task<Tournament> UpdateTournamentAsync(string tournament, TournamentInfo tournamentInfo, bool ignoreNulls = true);
+
+        /// <summary>
+        /// Updates an existing tournament.
+        /// </summary>
         /// <param name="tournament">The tournament to update.</param>
         /// <param name="tournamentInfo">The new details of the tournament.</param>
         /// <param name="ignoreNulls">Indicates whether null-valued properties of tournamentInfo should be sent to Challonge.</param>
@@ -56,10 +69,37 @@ namespace Challonge.Api
         /// <summary>
         /// Deletes a tournament.
         /// </summary>
+        /// <param name="tournament">
+        /// The tournament to delete.
+        /// Can be the tournament's id (e.g. 10230) or url (e.g 'single_elim' for 'challonge.com/single_elim')
+        /// If assigned to a subdomain, URL format must be subdomain-tournament_url (e.g. 'test-mytourney' for 'test.challonge.com/mytourney') 
+        /// </param>
+        /// <returns>An empty task.</returns>
+        public Task DeleteTournamentAsync(string tournament);
+        
+        /// <summary>
+        /// Deletes a tournament.
+        /// </summary>
         /// <param name="tournament">The tournament to delete.</param>
         /// <returns>An empty task.</returns>
         public Task DeleteTournamentAsync(Tournament tournament);
 
+        /// <summary>
+        /// Processes a tournament's check-ins:
+        /// <list type="number">
+        /// <item>Marks participants who have not checked in as inactive.</item>
+        /// <item>Moves inactive participants to bottom seeds, ordered by original seed.</item>
+        /// <item>Transitions the tournament state from "checking_in" to "checked_in."</item>
+        /// </list>
+        /// </summary>
+        /// <param name="tournament">
+        /// The tournament for which to process check-ins.
+        /// Can be the tournament's id (e.g. 10230) or url (e.g 'single_elim' for 'challonge.com/single_elim')
+        /// If assigned to a subdomain, URL format must be subdomain-tournament_url (e.g. 'test-mytourney' for 'test.challonge.com/mytourney') 
+        /// </param>
+        /// <returns>A task representing the the updated tournament.</returns>
+        public Task<Tournament> ProcessTournamentCheckInsAsync(string tournament);
+        
         /// <summary>
         /// Processes a tournament's check-ins:
         /// <list type="number">
@@ -79,10 +119,36 @@ namespace Challonge.Api
         /// <item>Transitions the tournament state from "checking_in" or "checked_in" to "pending."</item>
         /// </list>
         /// </summary>
+        /// <param name="tournament">
+        /// The tournament for which to cancel check-in.
+        /// Can be the tournament's id (e.g. 10230) or url (e.g 'single_elim' for 'challonge.com/single_elim')
+        /// If assigned to a subdomain, URL format must be subdomain-tournament_url (e.g. 'test-mytourney' for 'test.challonge.com/mytourney') 
+        /// </param>
+        /// <returns>A task representing the updated tournament.</returns>
+        public Task<Tournament> AbortTournamentCheckInAsync(string tournament);
+        
+        /// <summary>
+        /// Aborts a tournament's check-in:
+        /// <list type="number">
+        /// <item>Makes all participants active and clears their "checked_in_at" times.</item>
+        /// <item>Transitions the tournament state from "checking_in" or "checked_in" to "pending."</item>
+        /// </list>
+        /// </summary>
         /// <param name="tournament">The tournament for which to cancel check-in.</param>
         /// <returns>A task representing the updated tournament.</returns>
         public Task<Tournament> AbortTournamentCheckInAsync(Tournament tournament);
 
+        /// <summary>
+        /// Starts a tournament.
+        /// </summary>
+        /// <param name="tournament">
+        /// The tournament to start.
+        /// Can be the tournament's id (e.g. 10230) or url (e.g 'single_elim' for 'challonge.com/single_elim')
+        /// If assigned to a subdomain, URL format must be subdomain-tournament_url (e.g. 'test-mytourney' for 'test.challonge.com/mytourney')
+        /// </param>
+        /// <returns>A task representing the updated tournament.</returns>
+        public Task<Tournament> StartTournamentAsync(string tournament);
+        
         /// <summary>
         /// Starts a tournament.
         /// </summary>
@@ -93,6 +159,16 @@ namespace Challonge.Api
         /// <summary>
         /// Finalizes a tournament's results.
         /// </summary>
+        /// <param name="tournament">
+        /// The tournament to finalize.Can be the tournament's id (e.g. 10230) or url (e.g 'single_elim' for 'challonge.com/single_elim')
+        /// If assigned to a subdomain, URL format must be subdomain-tournament_url (e.g. 'test-mytourney' for 'test.challonge.com/mytourney') 
+        /// </param>
+        /// <returns>A task representing the updated tournament.</returns>
+        public Task<Tournament> FinalizeTournamentAsync(string tournament);
+        
+        /// <summary>
+        /// Finalizes a tournament's results.
+        /// </summary>
         /// <param name="tournament">The tournament to finalize.</param>
         /// <returns>A task representing the updated tournament.</returns>
         public Task<Tournament> FinalizeTournamentAsync(Tournament tournament);
@@ -100,10 +176,32 @@ namespace Challonge.Api
         /// <summary>
         /// Reverts a tournament back to its original state, clearing all scores and attachments.
         /// </summary>
+        /// <param name="tournament">
+        /// The tournament to reset.
+        /// Can be the tournament's id (e.g. 10230) or url (e.g 'single_elim' for 'challonge.com/single_elim')
+        /// If assigned to a subdomain, URL format must be subdomain-tournament_url (e.g. 'test-mytourney' for 'test.challonge.com/mytourney')
+        /// </param>
+        /// <returns>A task representing the updated tournament.</returns>
+        public Task<Tournament> ResetTournamentAsync(string tournament);
+        
+        /// <summary>
+        /// Reverts a tournament back to its original state, clearing all scores and attachments.
+        /// </summary>
         /// <param name="tournament">The tournament to reset.</param>
         /// <returns>A task representing the updated tournament.</returns>
         public Task<Tournament> ResetTournamentAsync(Tournament tournament);
 
+        /// <summary>
+        /// Allows a tournament to start accepting predictions.
+        /// </summary>
+        /// <param name="tournament">
+        /// The tournament to open for predictions.
+        /// Can be the tournament's id (e.g. 10230) or url (e.g 'single_elim' for 'challonge.com/single_elim')
+        /// If assigned to a subdomain, URL format must be subdomain-tournament_url (e.g. 'test-mytourney' for 'test.challonge.com/mytourney')
+        /// </param>
+        /// <returns>A task representing the updated tournament.</returns>
+        public Task<Tournament> OpenTournamentForPredictionsAsync(string tournament);
+        
         /// <summary>
         /// Allows a tournament to start accepting predictions.
         /// </summary>


### PR DESCRIPTION
#6 : Allow calling the API directly with an object's id or url instead of the full object url.

I've only added methods overload that enable you to call the api without the full object url. **For other objects, you have to use the full object.**
If this should stay this way, #6 can be closed or linked to this PR. If I should add method overloads for the other objects, we keep #6 open and I'll edit this PR or make a new one