### PR TITLE
Issue #18 - Fix spelling on Median-Buchholz TieBreak Enum

### DIFF
--- a/Challonge/Objects/Enums.cs
+++ b/Challonge/Objects/Enums.cs
@@ -98,7 +98,7 @@ namespace Challonge.Objects
         PointsDifference,
         [EnumMember(Value = "match wins vs tied")]
         MatchWinsVsTied,
-        [EnumMember(Value = "median bucholz")]
-        MedianBucholz
+        [EnumMember(Value = "median buchholz")]
+        MedianBuchholz
     }
 }


### PR DESCRIPTION
JSON deserialization of responses from Challonge API for Swiss format events using the Median-Buchholz system for tiebreakers fails due to a spelling error in the TieBreak enum. This change should correct the problem.