### PR TITLE
make missing attributes nullable

### DIFF
--- a/Challonge/Objects/Tournament.cs
+++ b/Challonge/Objects/Tournament.cs
@@ -184,7 +184,7 @@ namespace Challonge.Objects
         public bool? PublicPredictionsBeforeStartTime { get; private set; }
 
         [JsonProperty("ranked")]
-        public bool Ranked { get; private set; }
+        public bool? Ranked { get; private set; }
 
         [JsonProperty("grand_finals_modifier")]
         [JsonConverter(typeof(StringEnumConverter))]
@@ -221,13 +221,13 @@ namespace Challonge.Objects
         public bool? OnlyStartMatchesWithStations { get; private set; }
 
         [JsonProperty("registration_fee")]
-        public double RegistrationFee { get; private set; }
+        public double? RegistrationFee { get; private set; }
 
         [JsonProperty("registration_type")]
         public string RegistrationType { get; private set; }
 
         [JsonProperty("split_participants")]
-        public bool SplitParticipants { get; private set; }
+        public bool? SplitParticipants { get; private set; }
 
         [JsonProperty("allowed_regions")]
         public IEnumerable<string> AllowedRegions { get; private set; }


### PR DESCRIPTION
I've gone through all of the attributes on Tournament.cs and compared them to the sample response here: 

https://api.challonge.com/v1/documents/tournaments/create

All of the attributes on Tournament.cs that do not appear on the sample response are either already explicitly nullable, are a nullable reference type (like a string), or they are changed by this pull request from non-nullable to nullable.

It might be fine to just delete these (and maybe other?) unused(?) attributes, but I don't know whether these are truly unused or they just happen to be missing from these recent responses, so making them nullable seems like a safe middle-ground.

In any case, I THINK this change will solve the problem described in Issue #20 (assuming there isn't something more nefarious going on).